### PR TITLE
Update lat.c and rep.c for linux kernel version 5.1

### DIFF
--- a/src/kernel/lat.c
+++ b/src/kernel/lat.c
@@ -383,7 +383,7 @@ static int latencyfs_fill_super(struct super_block *sb, void *data, int silent)
 	ret = bdev_dax_supported(sb, PAGE_SIZE);
 	pr_info("%s: dax_supported = %d; bdev->super=0x%p",
 			__func__, ret, sb->s_bdev->bd_super);
-	if (ret)
+	if (!ret)
 	{
 		pr_err("device does not support DAX\n");
 		return ret;
@@ -423,7 +423,7 @@ static int latencyfs_fill_super(struct super_block *sb, void *data, int silent)
 
 	root->i_ino = 0;
 	root->i_sb = sb;
-	root->i_atime = root->i_mtime = root->i_ctime = current_kernel_time();
+	root->i_atime = root->i_mtime = root->i_ctime = ktime_to_timespec64(ktime_get_real());
 	inode_init_owner(root, NULL, S_IFDIR);
 
 	sb->s_root = d_make_root(root);
@@ -434,7 +434,7 @@ static int latencyfs_fill_super(struct super_block *sb, void *data, int silent)
 
 	global_sbi = sbi;
 
-	return ret;
+	return !ret;
 }
 
 static struct dentry *latencyfs_mount(struct file_system_type *fs_type,

--- a/src/kernel/rep.c
+++ b/src/kernel/rep.c
@@ -75,10 +75,10 @@ static int reportfs_fill_super(struct super_block *sb, void *data, int silent) {
   sb->s_fs_info = sbi;
   sbi->sb = sb;
 
-  ret = bdev_dax_supported(sb, PAGE_SIZE);
+  ret = bdev_dax_supported(sb->s_bdev, PAGE_SIZE);
   pr_info("%s: dax_supported = %d; bdev->super=0x%p", __func__, ret,
           sb->s_bdev->bd_super);
-  if (ret) {
+  if (!ret) {
     pr_err("device does not support DAX\n");
     return ret;
   }
@@ -115,7 +115,7 @@ static int reportfs_fill_super(struct super_block *sb, void *data, int silent) {
 
   root->i_ino = 0;
   root->i_sb = sb;
-  root->i_atime = root->i_mtime = root->i_ctime = current_kernel_time();
+  root->i_atime = root->i_mtime = root->i_ctime = ktime_to_timespec64(ktime_get_real());
   inode_init_owner(root, NULL, S_IFDIR);
 
   sb->s_root = d_make_root(root);


### PR DESCRIPTION
I modified two files, lat.c and rep.c, for linux kernel 5.1.

1. Modified if statements and caller parts so that the "bdev_dax_supported" function works correctly.
2. Modified some deprecated functions that was not used in the linux kernel 5.1.

It works on linux kernel verison 5.1.
Thank you.